### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import aiosqlite
-from typing import List, Optional, Tuple, Any, Dict
 from config import DB_PATH
 
 # Гарантируем, что директория для БД существует


### PR DESCRIPTION
## Summary
- remove unused `typing` imports from db module

## Testing
- `ruff check db.py`

------
https://chatgpt.com/codex/tasks/task_e_689daa7641288323a5b1388e73aeea06