### PR TITLE
Disable HTML parse mode for Telegram bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from aiogram import Bot, Dispatcher
-from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.default import DefaultBotProperties
 
 from config import TELEGRAM_TOKEN, POLL_INTERVAL
@@ -105,7 +104,7 @@ async def main():
 
     bot = Bot(
         token=TELEGRAM_TOKEN,
-        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+        default=DefaultBotProperties(parse_mode=None),
     )
     dp = Dispatcher()
     dp.include_router(router)


### PR DESCRIPTION
## Summary
- Remove unused ParseMode import and disable default HTML parse mode for the bot

## Testing
- `python -m py_compile app.py handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc2ed173083239e805058a7ee47ef