### PR TITLE
Validate positive percent for set_pct alerts

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -83,6 +83,9 @@ async def cmd_set_pct(message: Message):
     except ValueError:
         await message.answer("PERCENT должен быть числом")
         return
+    if percent <= 0:
+        await message.answer("PERCENT должен быть положительным")
+        return
     try:
         interval, seconds = parse_window(window)
     except ValueError as e:


### PR DESCRIPTION
## Summary
- ensure `/set_pct` rejects non-positive PERCENT values
- notify users with "PERCENT должен быть положительным"
- only create percent alerts when validation passes

## Testing
- `python -m py_compile handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc2feaa80832395362a8e1d53f7da