### PR TITLE
Handle invalid POLL_INTERVAL env var

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,21 @@
 import os
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "")
-POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "15"))
+
+# POLL_INTERVAL should be an integer number of seconds
+_poll_interval = os.getenv("POLL_INTERVAL", "15")
+try:
+    POLL_INTERVAL = int(_poll_interval)
+except ValueError:
+    logging.error(
+        "Invalid POLL_INTERVAL '%s'. Expected an integer. Using default of 15 seconds.",
+        _poll_interval,
+    )
+    POLL_INTERVAL = 15
+
 DB_PATH = os.getenv("DB_PATH", ".data/bot.db")
 BINANCE_API = os.getenv("BINANCE_API", "https://api.binance.com")


### PR DESCRIPTION
## Summary
- add error handling for `POLL_INTERVAL` in config
- log invalid env var and fall back to default

## Testing
- `pytest`
- `python -m py_compile config.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc3067f7483239b75f773f32ce1f8