### PR TITLE
Handle HTTP errors from Binance API

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,10 +34,14 @@ async def poller(bot: Bot):
                         continue
                     if symbol not in prices_cache:
                         try:
-                            prices_cache[symbol] = await client.get_price(symbol)
+                            price = await client.get_price(symbol)
                         except Exception as e:
                             logging.warning("price failed for %s: %s", symbol, e)
                             continue
+                        if price is None:
+                            logging.warning("price failed for %s: no data", symbol)
+                            continue
+                        prices_cache[symbol] = price
 
                     price = prices_cache[symbol]
                     op = a.get("op")
@@ -59,10 +63,14 @@ async def poller(bot: Bot):
                     key = (symbol, interval)
                     if key not in klines_cache:
                         try:
-                            klines_cache[key] = await client.get_klines(symbol, interval, limit=2)
+                            kl = await client.get_klines(symbol, interval, limit=2)
                         except Exception as e:
                             logging.warning("klines failed for %s %s: %s", symbol, interval, e)
                             continue
+                        if not kl:
+                            logging.warning("klines failed for %s %s: no data", symbol, interval)
+                            continue
+                        klines_cache[key] = kl
 
                     kl = klines_cache[key]
                     if len(kl) < 2:

--- a/handlers.py
+++ b/handlers.py
@@ -38,7 +38,10 @@ async def cmd_price(message: Message):
     client = BinanceClient()
     try:
         price = await client.get_price(symbol)
-        await message.answer(f"{symbol}: {price:.8f}")
+        if price is None:
+            await message.answer("Ошибка получения цены")
+        else:
+            await message.answer(f"{symbol}: {price:.8f}")
     except Exception as e:
         await message.answer(f"Ошибка получения цены: {e}")
     finally:


### PR DESCRIPTION
## Summary
- log and handle `httpx.HTTPError` in Binance client
- propagate special values to callers and adjust handlers/poller

## Testing
- `python -m py_compile binance.py handlers.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc30f83d4832380f3d2faa0d9db39