### PR TITLE
Replace window parse error messages with English

### DIFF
--- a/binance.py
+++ b/binance.py
@@ -45,6 +45,6 @@ WINDOW_TO_INTERVAL = {
 def parse_window(window: str):
     window = window.strip().lower()
     if window not in WINDOW_TO_INTERVAL:
-        raise ValueError("Ошибка окна: используйте 15m, 30m, 1h, 4h, 1d")
+        raise ValueError("Invalid window: use 15m, 30m, 1h, 4h, or 1d")
     interval, seconds = WINDOW_TO_INTERVAL[window]
     return interval, seconds

--- a/tradingview.py
+++ b/tradingview.py
@@ -83,7 +83,7 @@ WINDOW_TO_INTERVAL = {
 def parse_window(window: str):
     window = window.strip().lower()
     if window not in WINDOW_TO_INTERVAL:
-        raise ValueError("Ошибка окна: используйте 15m, 30m, 1h, 4h, 1d")
+        raise ValueError("Invalid window: use 15m, 30m, 1h, 4h, or 1d")
     interval, seconds = WINDOW_TO_INTERVAL[window]
     return interval, seconds
 


### PR DESCRIPTION
## Summary
- Replace Russian window parse error message with English in tradingview.py and binance.py
- Demonstrate cmd_set_pct returns the new English message on invalid windows

## Testing
- `python - <<'PY'
import asyncio
from handlers import cmd_set_pct

class DummyMessage:
    def __init__(self, text):
        self.text = text
        self.from_user = type('User', (), {'id': 1})()
        self.chat = type('Chat', (), {'id': 1})()
    async def answer(self, text):
        print('BOT:', text)

async def main():
    msg = DummyMessage('/set_pct BTCUSDT 5 2h')  # invalid window
    await cmd_set_pct(msg)

asyncio.run(main())
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ddb7130008323b5d9527df43a7b42