### PR TITLE
Translate handler messages to English

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -12,12 +12,12 @@ router = Router()
 SYMBOL_RE = re.compile(r'^[A-Z0-9]{5,15}$')
 
 HELP_TEXT = (
-    "Привет! Я крипто‑алерт бот. Доступные команды:\n\n"
-    "/price <SYMBOL> — текущая цена (пример: /price BTCUSDT)\n"
-    "/set <SYMBOL> <OP> <PRICE> — ценовой алерт (пример: /set BTCUSDT >= 65000)\n"
-    "/set_pct <SYMBOL> <PERCENT> <WINDOW> — алерт на % за окно (пример: /set_pct BTCUSDT 5 1h)\n"
-    "/list — список ваших алертов\n"
-    "/delete <ID> — удалить алерт"
+    "Hello! I'm a crypto alert bot. Available commands:\n\n"
+    "/price <SYMBOL> — current price (example: /price BTCUSDT)\n"
+    "/set <SYMBOL> <OP> <PRICE> — price alert (example: /set BTCUSDT >= 65000)\n"
+    "/set_pct <SYMBOL> <PERCENT> <WINDOW> — % change alert (example: /set_pct BTCUSDT 5 1h)\n"
+    "/list — list your alerts\n"
+    "/delete <ID> — delete an alert"
 )
 
 @router.message(Command("start"))
@@ -29,21 +29,21 @@ async def cmd_start(message: Message):
 async def cmd_price(message: Message):
     parts = message.text.strip().split()
     if len(parts) != 2:
-        await message.answer("Использование: /price <SYMBOL> (например: /price BTCUSDT)")
+        await message.answer("Usage: /price <SYMBOL> (e.g., /price BTCUSDT)")
         return
     symbol = parts[1].upper()
     if not SYMBOL_RE.match(symbol):
-        await message.answer("Некорректный символ. Пример: BTCUSDT")
+        await message.answer("Invalid symbol. Example: BTCUSDT")
         return
     client = TradingViewClient()
     try:
         price = await client.get_price(symbol)
         if price is None:
-            await message.answer("Ошибка получения цены")
+            await message.answer("Error retrieving price")
         else:
             await message.answer(f"{symbol}: {price:.8f}")
     except Exception as e:
-        await message.answer(f"Ошибка получения цены: {e}")
+        await message.answer(f"Error retrieving price: {e}")
     finally:
         await client.close()
 
@@ -52,42 +52,42 @@ async def cmd_set(message: Message):
     # /set BTCUSDT >= 65000
     parts = message.text.strip().split()
     if len(parts) != 4:
-        await message.answer("Формат: /set <SYMBOL> <OP> <PRICE>\nПример: /set BTCUSDT >= 65000")
+        await message.answer("Format: /set <SYMBOL> <OP> <PRICE>\nExample: /set BTCUSDT >= 65000")
         return
     symbol, op, price = parts[1].upper(), parts[2], parts[3]
     if not SYMBOL_RE.match(symbol):
-        await message.answer("Некорректный символ. Пример: BTCUSDT")
+        await message.answer("Invalid symbol. Example: BTCUSDT")
         return
     if op not in (">=", "<="):
-        await message.answer("OP должен быть '>=' или '<='")
+        await message.answer("OP must be '>=' or '<='")
         return
     try:
         target = float(price.replace(',', '.'))
     except ValueError:
-        await message.answer("PRICE должен быть числом")
+        await message.answer("PRICE must be a number")
         return
 
     alert_id = await add_price_alert(message.from_user.id, message.chat.id, symbol, op, target)
-    await message.answer(f"✅ Алерт #{alert_id} создан: {symbol} {op} {target}")
+    await message.answer(f"✅ Alert #{alert_id} created: {symbol} {op} {target}")
 
 @router.message(Command("set_pct"))
 async def cmd_set_pct(message: Message):
     # /set_pct BTCUSDT 5 1h
     parts = message.text.strip().split()
     if len(parts) != 4:
-        await message.answer("Формат: /set_pct <SYMBOL> <PERCENT> <WINDOW>\nПример: /set_pct BTCUSDT 5 1h")
+        await message.answer("Format: /set_pct <SYMBOL> <PERCENT> <WINDOW>\nExample: /set_pct BTCUSDT 5 1h")
         return
     symbol, pct_str, window = parts[1].upper(), parts[2], parts[3]
     if not SYMBOL_RE.match(symbol):
-        await message.answer("Некорректный символ. Пример: BTCUSDT")
+        await message.answer("Invalid symbol. Example: BTCUSDT")
         return
     try:
         percent = float(pct_str.replace(',', '.'))
     except ValueError:
-        await message.answer("PERCENT должен быть числом")
+        await message.answer("PERCENT must be a number")
         return
     if percent <= 0:
-        await message.answer("PERCENT должен быть положительным")
+        await message.answer("PERCENT must be positive")
         return
     try:
         interval, seconds = parse_window(window)
@@ -96,13 +96,13 @@ async def cmd_set_pct(message: Message):
         return
 
     alert_id = await add_pct_alert(message.from_user.id, message.chat.id, symbol, percent, window, seconds)
-    await message.answer(f"✅ Алерт #{alert_id} создан: {symbol} ±{percent}% за {window}")
+    await message.answer(f"✅ Alert #{alert_id} created: {symbol} ±{percent}% over {window}")
 
 @router.message(Command("list"))
 async def cmd_list(message: Message):
     rows = await list_alerts(message.from_user.id)
     if not rows:
-        await message.answer("У вас нет алертов.")
+        await message.answer("You have no alerts.")
         return
     lines = []
     for r in rows:
@@ -116,15 +116,15 @@ async def cmd_list(message: Message):
 async def cmd_delete(message: Message):
     parts = message.text.strip().split()
     if len(parts) != 2:
-        await message.answer("Формат: /delete <ID>")
+        await message.answer("Format: /delete <ID>")
         return
     try:
         alert_id = int(parts[1])
     except ValueError:
-        await message.answer("ID должен быть числом")
+        await message.answer("ID must be a number")
         return
     ok = await delete_alert(alert_id, message.from_user.id)
     if ok:
-        await message.answer(f"🗑️ Алерт #{alert_id} удалён")
+        await message.answer(f"🗑️ Alert #{alert_id} deleted")
     else:
-        await message.answer("Не найден алерт с таким ID (или он не ваш).")
+        await message.answer("No alert found with that ID (or it isn't yours).")


### PR DESCRIPTION
## Summary
- Replace Russian user-facing text with English in `handlers.py`

## Testing
- `python -m py_compile handlers.py`
- `flake8 handlers.py` *(fails: command not found; proxy prevented installing flake8)*

------
https://chatgpt.com/codex/tasks/task_e_689de9b3e9848323a890a1200b80a40e